### PR TITLE
Update all Nuget packages but Polly

### DIFF
--- a/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/App.config
+++ b/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/App.config
@@ -12,7 +12,23 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="CsvHelper" publicKeyToken="8c4959082be5c823" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/Capgemini.Xrm.Datamigration.Examples.csproj
+++ b/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/Capgemini.Xrm.Datamigration.Examples.csproj
@@ -34,54 +34,49 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Capgemini.DataMigration.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
     </Reference>
     <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
     </Reference>
     <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
     </Reference>
     <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
     </Reference>
     <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
     </Reference>
     <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.5.0.2\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
+      <HintPath>..\packages\Capgemini.Xrm.DataMigration.Engine.2.7.0\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
     </Reference>
-    <Reference Include="CsvHelper, Version=6.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\packages\CsvHelper.6.1.0\lib\net45\CsvHelper.dll</HintPath>
+    <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvHelper.12.1.2\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.17\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.12\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.13\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.17\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.9\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.17\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.9\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.17\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.12\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.13\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly.5.8.0\lib\net45\Polly.dll</HintPath>
@@ -93,13 +88,33 @@
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Workflow.Activities" />
     <Reference Include="System.Workflow.ComponentModel" />
     <Reference Include="System.Workflow.Runtime" />
@@ -107,7 +122,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/packages.config
+++ b/Capgemini.Xrm.Datamigration/Capgemini.Xrm.Datamigration.Examples/packages.config
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Capgemini.Xrm.DataMigration.Engine" version="2.5.0.2" targetFramework="net462" />
-  <package id="CsvHelper" version="6.1.0" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.9" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.9" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.9" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.12" targetFramework="net462" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Capgemini.Xrm.DataMigration.Engine" version="2.7.0" targetFramework="net462" />
+  <package id="CsvHelper" version="12.1.2" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.17" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.17" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.17" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.0.13" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.2.2" targetFramework="net462" />
+  <package id="Microsoft.NETCore.Platforms" version="3.0.0" targetFramework="net462" />
+  <package id="Microsoft.NETCore.Targets" version="3.0.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Polly" version="5.8.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
+  <package id="System.Private.Uri" version="4.3.2" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Polly could not be updated due to:
```Unhandled Exception: System.IO.FileLoadException: Could not load file or assembly 'Polly, Version=5.8.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
   at Capgemini.DataMigration.Resiliency.Polly.PollyFluentPolicy.AddType[T]()
   at Capgemini.DataMigration.Resiliency.Polly.ServiceRetryExecutor.Execute[T](Func`1 p)
   at Capgemini.Xrm.DataMigration.Repositories.EntityRepository.ExecuteMultipleWithRetry(List`1 entities, Func`2 orgRequest)
   at Capgemini.Xrm.DataMigration.Repositories.EntityRepository.CreateUpdateEntities(List`1 entities)
   at Capgemini.Xrm.DataMigration.CrmStore.DataStores.DataCrmStoreWriter.PersistUsingUpsertRequest(Int32 pageNo, List`1 entities, IEntityRepository repo)
   at Capgemini.Xrm.DataMigration.CrmStore.DataStores.DataCrmStoreWriter.PersistPageData(Int32 pageNo, List`1 pageData, IEntityRepository repo)
   at Capgemini.Xrm.DataMigration.CrmStore.DataStores.DataCrmStoreWriter.SaveBatchDataToStore(List`1 entities)
   at Capgemini.DataMigration.Core.GenericDataMigrator`2.PerformMigratePass(Int32 passNo, List`1 processors)
   at Capgemini.DataMigration.Core.GenericDataMigrator`2.MigrateData()
   at Capgemini.Xrm.Datamigration.Examples.Program.ImportData(String connectionString, String schemaPath, String exportFolderPath) in C:\code\cap\xrm-datamigration\Capgemini.Xrm.Datamigration\Capgemini.Xrm.Datamigration.Examples\Program.cs:line 88
   at Capgemini.Xrm.Datamigration.Examples.Program.Main(String[] args) in C:\code\cap\xrm-datamigration\Capgemini.Xrm.Datamigration\Capgemini.Xrm.Datamigration.Examples\Program.cs:line 43
```

Tested with SubjectsAndArticles. 