### PR TITLE
Set entity reference logical name if not in source

### DIFF
--- a/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.nuspec
+++ b/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Capgemini.Xrm.DataMigration.Cli</id>
-    <version>2.0.0.7</version>
+    <version>2.0.0.8</version>
     <title>Capgemini Xrm DataMigration Engine - CLI</title>
     <authors>Capgemini</authors>
     <owners>Capgemini</owners>

--- a/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.nuspec
+++ b/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Capgemini.Xrm.DataMigration.Engine</id>
-    <version>3.0.0.7</version>
+    <version>3.0.0.8</version>
     <title>Capgemini Xrm DataMigration Engine</title>
     <authors>Capgemini</authors>
     <owners>Capgemini</owners>

--- a/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/MapEntityProcessor.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/MapEntityProcessor.cs
@@ -341,6 +341,11 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
                 {
                     var originalEntityReference = (EntityReference)entity.OriginalEntity.Attributes[originalFieldName];
                     originalEntityReference.Id = replaceGuid;
+
+                    if (string.IsNullOrEmpty(originalEntityReference.LogicalName))
+                    {
+                        originalEntityReference.LogicalName = metCache.GetLookUpEntityName(entity.LogicalName, originalFieldName);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Previous pull request removed the code that set the entity logical name of an entity reference when doing alias mapping and assumed the logical name would be set in the source data. However, this may not be the case for csv imports.