### PR TITLE
feat: upgrade `Microsoft.CrmSdk.CoreAssemblies` to 9.0.2.29

### DIFF
--- a/samples/Capgemini.Xrm.DataMigration.Samples.csproj
+++ b/samples/Capgemini.Xrm.DataMigration.Samples.csproj
@@ -45,7 +45,7 @@
       <HintPath>..\packages\CsvHelper.12.1.3\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.17\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -54,7 +54,7 @@
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.13\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.17\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.17\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/samples/packages.config
+++ b/samples/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.17" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.17" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.17" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.0.13" targetFramework="net462" />

--- a/src/Capgemini.DataMigration.Core/Capgemini.DataMigration.Core.csproj
+++ b/src/Capgemini.DataMigration.Core/Capgemini.DataMigration.Core.csproj
@@ -45,15 +45,29 @@
     <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.12.1.3\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Capgemini.DataMigration.Core/Capgemini.DataMigration.Core.csproj
+++ b/src/Capgemini.DataMigration.Core/Capgemini.DataMigration.Core.csproj
@@ -44,36 +44,75 @@
   <ItemGroup>
     <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.12.1.3\lib\net45\CsvHelper.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.DirectoryServices" />
-    <Reference Include="System.DirectoryServices.AccountManagement" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.DirectoryServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.DirectoryServices.AccountManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.IdentityModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Runtime.Caching, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.ServiceModel.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\GlobalSuppressions.cs">

--- a/src/Capgemini.DataMigration.Core/packages.config
+++ b/src/Capgemini.DataMigration.Core/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />

--- a/src/Capgemini.DataMigration.Resiliency.Polly/Capgemini.DataMigration.Resiliency.Polly.csproj
+++ b/src/Capgemini.DataMigration.Resiliency.Polly/Capgemini.DataMigration.Resiliency.Polly.csproj
@@ -42,12 +42,25 @@
     <CodeAnalysisRuleSet>Capgemini.DataMigration.Resiliency.Polly.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+    </Reference>
     <Reference Include="Polly, Version=5.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Polly.5.9.0\lib\net45\Polly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Capgemini.DataMigration.Resiliency.Polly/Capgemini.DataMigration.Resiliency.Polly.csproj
+++ b/src/Capgemini.DataMigration.Resiliency.Polly/Capgemini.DataMigration.Resiliency.Polly.csproj
@@ -44,12 +44,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Polly, Version=5.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Polly.5.9.0\lib\net45\Polly.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Capgemini.DataMigration.Resiliency.Polly/packages.config
+++ b/src/Capgemini.DataMigration.Resiliency.Polly/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Polly" version="5.9.0" targetFramework="net462" />

--- a/src/Capgemini.DataScrambler/Capgemini.DataScrambler.csproj
+++ b/src/Capgemini.DataScrambler/Capgemini.DataScrambler.csproj
@@ -41,9 +41,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Capgemini.DataScrambler/Capgemini.DataScrambler.csproj
+++ b/src/Capgemini.DataScrambler/Capgemini.DataScrambler.csproj
@@ -39,8 +39,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Capgemini.DataScrambler/packages.config
+++ b/src/Capgemini.DataScrambler/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net461" developmentDependency="true" />
   <package id="SecurityCodeScan" version="3.5.3.0" targetFramework="net462" developmentDependency="true" />

--- a/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.csproj
@@ -48,33 +48,43 @@
   <ItemGroup>
     <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.27\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.Deployment.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.Workflow.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.27\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -83,6 +93,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
@@ -90,18 +101,23 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Reflection.TypeExtensions, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.6.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />

--- a/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Cli/Capgemini.Xrm.DataMigration.Cli.csproj
@@ -50,7 +50,7 @@
       <HintPath>..\..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -62,7 +62,7 @@
       <HintPath>..\..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.27\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.Deployment.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/src/Capgemini.Xrm.DataMigration.Cli/Program.cs
+++ b/src/Capgemini.Xrm.DataMigration.Cli/Program.cs
@@ -44,7 +44,7 @@ namespace Capgemini.Xrm.DataMigration.Cli
             {
                 new CrmFileDataImporter(
                     Logger,
-                    new EntityRepository(serviceClient.OrganizationServiceProxy, new ServiceRetryExecutor()),
+                    new EntityRepository(serviceClient, new ServiceRetryExecutor()),
                     CrmImportConfig.GetConfiguration(options.ConfigurationFile),
                     CancellationToken.None).MigrateData();
                 return 0;

--- a/src/Capgemini.Xrm.DataMigration.Cli/packages.config
+++ b/src/Capgemini.Xrm.DataMigration.Cli/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.18" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.18" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.27" targetFramework="net462" developmentDependency="true" />

--- a/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
@@ -44,12 +44,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
@@ -43,10 +43,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Capgemini.Xrm.DataMigration.Core/packages.config
+++ b/src/Capgemini.Xrm.DataMigration.Core/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />

--- a/src/Capgemini.Xrm.DataMigration.CrmStore/Capgemini.Xrm.DataMigration.CrmStore.csproj
+++ b/src/Capgemini.Xrm.DataMigration.CrmStore/Capgemini.Xrm.DataMigration.CrmStore.csproj
@@ -44,12 +44,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Capgemini.Xrm.DataMigration.CrmStore/Capgemini.Xrm.DataMigration.CrmStore.csproj
+++ b/src/Capgemini.Xrm.DataMigration.CrmStore/Capgemini.Xrm.DataMigration.CrmStore.csproj
@@ -43,10 +43,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Capgemini.Xrm.DataMigration.CrmStore/packages.config
+++ b/src/Capgemini.Xrm.DataMigration.CrmStore/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />

--- a/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
@@ -44,15 +44,19 @@
   <ItemGroup>
     <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.12.1.3\lib\net45\CsvHelper.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,6 +70,7 @@
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
@@ -46,10 +46,10 @@
       <HintPath>..\..\packages\CsvHelper.12.1.3\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Capgemini.Xrm.DataMigration.Engine/packages.config
+++ b/src/Capgemini.Xrm.DataMigration.Engine/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="SecurityCodeScan" version="3.5.3.0" targetFramework="net462" developmentDependency="true" />

--- a/src/Capgemini.Xrm.DataMigration.FileStore/Capgemini.Xrm.DataMigration.FileStore.csproj
+++ b/src/Capgemini.Xrm.DataMigration.FileStore/Capgemini.Xrm.DataMigration.FileStore.csproj
@@ -42,6 +42,12 @@
     <CodeAnalysisRuleSet>Capgemini.Xrm.DataMigration.FileStore.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
@@ -61,12 +67,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.Crm.Sdk.Proxy">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.24\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.24\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/Capgemini.Xrm.DataMigration.FileStore/Capgemini.Xrm.DataMigration.FileStore.csproj
+++ b/src/Capgemini.Xrm.DataMigration.FileStore/Capgemini.Xrm.DataMigration.FileStore.csproj
@@ -44,9 +44,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,6 +61,7 @@
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Capgemini.Xrm.DataMigration.FileStore/packages.config
+++ b/src/Capgemini.Xrm.DataMigration.FileStore/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.24" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />

--- a/tests/Capgemini.DataMigration.Core.Tests.Base/Capgemini.DataMigration.Core.Tests.Base.csproj
+++ b/tests/Capgemini.DataMigration.Core.Tests.Base/Capgemini.DataMigration.Core.Tests.Base.csproj
@@ -45,7 +45,7 @@
       <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -54,7 +54,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.DataMigration.Core.Tests.Base/packages.config
+++ b/tests/Capgemini.DataMigration.Core.Tests.Base/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />

--- a/tests/Capgemini.DataMigration.Core.Tests.Unit/Capgemini.DataMigration.Core.Tests.Unit.csproj
+++ b/tests/Capgemini.DataMigration.Core.Tests.Unit/Capgemini.DataMigration.Core.Tests.Unit.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -66,7 +66,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.DataMigration.Core.Tests.Unit/packages.config
+++ b/tests/Capgemini.DataMigration.Core.Tests.Unit/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />

--- a/tests/Capgemini.DataScrambler.Tests.Unit/Capgemini.DataScrambler.Tests.Unit.csproj
+++ b/tests/Capgemini.DataScrambler.Tests.Unit/Capgemini.DataScrambler.Tests.Unit.csproj
@@ -51,11 +51,17 @@
     <Reference Include="FluentAssertions, Version=5.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>
@@ -63,15 +69,23 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/tests/Capgemini.DataScrambler.Tests.Unit/packages.config
+++ b/tests/Capgemini.DataScrambler.Tests.Unit/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />

--- a/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/Capgemini.Xrm.DataMigration.Core.IntegrationTests.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/Capgemini.Xrm.DataMigration.Core.IntegrationTests.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.7.0.0\lib\net35\microsoft.identitymodel.dll</HintPath>
@@ -74,7 +74,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.Deployment.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/Helpers/ConnectionHelper.cs
+++ b/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/Helpers/ConnectionHelper.cs
@@ -26,24 +26,8 @@ namespace Capgemini.Xrm.DataMigration.Core.IntegrationTests
                 connectionString = $"RequireNewInstance=True; {connectionString}";
             }
 
-            using (var serviceClient = new CrmServiceClient(connectionString))
-            {
-                if (serviceClient.OrganizationWebProxyClient != null)
-                {
-                    var service = serviceClient.OrganizationWebProxyClient;
-                    service.InnerChannel.OperationTimeout = new System.TimeSpan(1, 0, 0);
-                    return service;
-                }
-
-                if (serviceClient.OrganizationServiceProxy != null)
-                {
-                    var service = serviceClient.OrganizationServiceProxy;
-                    service.Timeout = new System.TimeSpan(1, 0, 0);
-                    return service;
-                }
-            }
-
-            throw new System.Exception("Cannot get IOrganizationService");
+            CrmServiceClient.MaxConnectionTimeout = new System.TimeSpan(1, 0, 0);
+            return new CrmServiceClient(connectionString);
         }
     }
 }

--- a/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.Core.IntegrationTests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.18" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.18" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.27" targetFramework="net462" />

--- a/tests/Capgemini.Xrm.DataMigration.Core.Tests.Unit/Capgemini.Xrm.DataMigration.Core.Tests.Unit.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.Core.Tests.Unit/Capgemini.Xrm.DataMigration.Core.Tests.Unit.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -62,7 +62,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.Core.Tests.Unit/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.Core.Tests.Unit/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />

--- a/tests/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -62,7 +62,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.CrmStore.Tests.Unit/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />

--- a/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/Capgemini.Xrm.DataMigration.Engine.Tests.Unit.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/Capgemini.Xrm.DataMigration.Engine.Tests.Unit.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -66,7 +66,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />

--- a/tests/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -62,7 +62,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.FileStore.Tests.Unit/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Moq" version="4.13.0" targetFramework="net462" />

--- a/tests/Capgemini.Xrm.DataMigration.Tests.Integration/Capgemini.Xrm.DataMigration.Tests.Integration.csproj
+++ b/tests/Capgemini.Xrm.DataMigration.Tests.Integration/Capgemini.Xrm.DataMigration.Tests.Integration.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -71,7 +71,7 @@
       <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.29\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.Deployment.9.0.2.18\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/tests/Capgemini.Xrm.DataMigration.Tests.Integration/Helpers/ConnectionHelper.cs
+++ b/tests/Capgemini.Xrm.DataMigration.Tests.Integration/Helpers/ConnectionHelper.cs
@@ -40,24 +40,8 @@ namespace Capgemini.Xrm.DataMigration.IntegrationTests
                 connectionString = $"RequireNewInstance=True; {connectionString}";
             }
 
-            using (var serviceClient = new CrmServiceClient(connectionString))
-            {
-                if (serviceClient.OrganizationWebProxyClient != null)
-                {
-                    var service = serviceClient.OrganizationWebProxyClient;
-                    service.InnerChannel.OperationTimeout = new System.TimeSpan(1, 0, 0);
-                    return service;
-                }
-
-                if (serviceClient.OrganizationServiceProxy != null)
-                {
-                    var service = serviceClient.OrganizationServiceProxy;
-                    service.Timeout = new System.TimeSpan(1, 0, 0);
-                    return service;
-                }
-            }
-
-            throw new System.Exception("Cannot get IOrganizationService");
+            CrmServiceClient.MaxConnectionTimeout = new System.TimeSpan(1, 0, 0);
+            return new CrmServiceClient(connectionString);
         }
     }
 }

--- a/tests/Capgemini.Xrm.DataMigration.Tests.Integration/packages.config
+++ b/tests/Capgemini.Xrm.DataMigration.Tests.Integration/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.18" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.29" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.18" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.18" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.27" targetFramework="net462" />


### PR DESCRIPTION
Upgrade `Microsoft.CrmSdk.CoreAssemblies` to 9.0.2.29 to provide OAuth connection string support for `CrmService`.