### PR TITLE
New logic to allow updates to be skipped where nothing has changed

### DIFF
--- a/src/Capgemini.DataMigration.Core/Cache/SimpleMemoryCache.cs
+++ b/src/Capgemini.DataMigration.Core/Cache/SimpleMemoryCache.cs
@@ -41,5 +41,20 @@ namespace Capgemini.DataMigration.Cache
                 return newIstance;
             }
         }
+
+        protected TItem TryGetCachedItem(string cacheKey)
+        {
+            var cachedObject = MemoryCache.Default.Get(cacheKey, null);
+            return (TItem)cachedObject;
+        }
+
+        protected void SetCachedItem (string cacheKey, TItem item)
+        {
+            // Store cached item
+            lock (MemoryCache.Default)
+            {
+                MemoryCache.Default.Set(cacheKey, item, new DateTimeOffset(DateTime.Now.AddMinutes(ExpirationMinutes)));
+            }
+        }
     }
 }

--- a/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityAttributeCache.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityAttributeCache.cs
@@ -78,27 +78,22 @@ namespace Capgemini.Xrm.DataMigration.Cache
 
         public static string GetFieldValueAsText(object val)
         {
-            if (val != null)
+            if (val is EntityReference)
             {
-                if (val is EntityReference)
-                {
-                    return string.Intern(((EntityReference)val).Id.ToString());
-                }
-                else if (val is OptionSetValue)
-                {
-                    return string.Intern(((OptionSetValue)val).Value.ToString());
-                }
-                else if (val is Money)
-                {
-                    return ((Money)val).Value.ToString();
-                }
-                else
-                {
-                    return val.ToString();
-                }
+                return string.Intern(((EntityReference)val).Id.ToString());
             }
-
-            return null;
+            else if (val is OptionSetValue)
+            {
+                return string.Intern(((OptionSetValue)val).Value.ToString());
+            }
+            else if (val is Money)
+            {
+                return ((Money)val).Value.ToString();
+            }
+            else
+            {
+                return val?.ToString();
+            }
         }
 
         protected override string[] CreateCachedItem(string cacheKey)

--- a/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityAttributeCache.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityAttributeCache.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Capgemini.DataMigration.Cache;
+using Capgemini.DataMigration.Exceptions;
+using Capgemini.Xrm.DataMigration.Core;
+using Capgemini.Xrm.DataMigration.Extensions;
+using Capgemini.Xrm.DataMigration.Model;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Capgemini.Xrm.DataMigration.Cache
+{
+    public class EntityAttributeCache : SimpleMemoryCache<string[]>
+    {
+        private const int MaxCachedRecords = 50000;
+        private const string CacheId = "EA";
+        private readonly string entityLogicalName;
+        private readonly string[] cacheFields;
+        private readonly IOrganizationService orgService;
+
+        public EntityAttributeCache(IOrganizationService orgService, string entityLogicalName, string[] fieldsToCache)
+        {
+            this.orgService = orgService;
+            this.entityLogicalName = entityLogicalName;
+            this.cacheFields = fieldsToCache;
+        }
+
+        public void LoadAllRecords()
+        {
+            var query = new QueryExpression(this.entityLogicalName)
+            {
+                ColumnSet = new ColumnSet(this.cacheFields)
+            };
+
+            var results = this.orgService.GetDataByQuery(query, MaxCachedRecords, true, MaxCachedRecords);
+
+            var tempList = new List<string>();
+
+            foreach (var record in results.Entities)
+            {
+                tempList.Clear();
+
+                foreach (var field in this.cacheFields)
+                {
+                    tempList.Add(GetFieldValueAsText(record, field));
+                }
+
+                this.SetCachedItem(CacheId + record.Id, tempList.ToArray());
+            }
+        }
+
+        public bool MatchCachedEntityAttributes(Guid entityId, IEnumerable<KeyValuePair<string, string>> attributes)
+        {
+            var cacheKey = CacheId + entityId;
+            var fields = this.GetCachedItem(cacheKey);
+
+            foreach (var a in attributes)
+            {
+                var fieldIndex = System.Array.IndexOf(this.cacheFields, a.Key);
+
+                if (fieldIndex < 0 || fields[fieldIndex] != a.Value)
+                {
+                    return false;
+                }
+            }
+
+            // Only if we have all fields and they are all the same
+            return true;
+        }
+
+        public static string GetFieldValueAsText(Entity e, string field)
+        {
+            return GetFieldValueAsText(e.Contains(field) ? e[field] : null);
+        }
+
+        public static string GetFieldValueAsText(object val)
+        {
+            if (val != null)
+            {
+                if (val is EntityReference)
+                {
+                    return string.Intern(((EntityReference)val).Id.ToString());
+                }
+                else if (val is OptionSetValue)
+                {
+                    return string.Intern(((OptionSetValue)val).Value.ToString());
+                }
+                else if (val is Money)
+                {
+                    return ((Money)val).Value.ToString();
+                }
+                else
+                {
+                    return val.ToString();
+                }
+            }
+
+            return null;
+        }
+
+        protected override string[] CreateCachedItem(string cacheKey)
+        {
+            if (cacheKey == null)
+            {
+                throw new ArgumentNullException(nameof(cacheKey));
+            }
+
+            string entityId = cacheKey.Substring(CacheId.Length);
+
+            var request = new RetrieveRequest
+            {
+                ColumnSet = new Microsoft.Xrm.Sdk.Query.ColumnSet(this.cacheFields),
+                Target = new EntityReference(this.entityLogicalName, new Guid(entityId))
+            };
+
+            var response = (RetrieveResponse)orgService.Execute(request);
+
+            return (from f in this.cacheFields select response.Entity.Contains(f) ? GetFieldValueAsText(response.Entity, f) : null).ToArray();
+        }
+    }
+}

--- a/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityMapLookupCache.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Cache/EntityMapLookupCache.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using Capgemini.DataMigration.Cache;
+using Capgemini.DataMigration.Exceptions;
+using Capgemini.Xrm.DataMigration.Core;
+using Capgemini.Xrm.DataMigration.Extensions;
+using Capgemini.Xrm.DataMigration.Model;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Capgemini.Xrm.DataMigration.Cache
+{
+    public class EntityMapLookupCache : SimpleMemoryCache<Guid?>
+    {
+        private const string CacheId = "CRMMapCache";
+        private readonly IOrganizationService orgService;
+
+        public EntityMapLookupCache(IOrganizationService orgService)
+        {
+            this.orgService = orgService;
+        }
+
+        public Guid GetGuidForMapping(string entityName, string[] filterFields, object[] filterValues)
+        {
+            if (filterFields == null || filterValues == null || filterFields.Length != filterValues.Length)
+            {
+                throw new ArgumentException("filter fields must have same length as filter values!");
+            }
+
+            var cacheKey = CacheId + "|" + entityName + "|" + string.Join(";", filterFields) + "|" + string.Join(";", from f in filterValues select f?.ToString() ?? "NULL");
+            var result = this.TryGetCachedItem(cacheKey);
+
+            if (result == null)
+            {
+                result = LookupGuidForMapping(entityName, filterFields, filterValues);
+
+                // We don't cache the absence of a record for the moment as it could be created during the Import - needs further cosnideration, but this isn't a performance bottleneck currently. 
+                if (result != Guid.Empty && result != null)
+                {
+                    this.SetCachedItem(cacheKey, result);
+                }
+            }
+
+            return result.Value;
+        }
+
+        protected override Guid? CreateCachedItem(string cacheKey)
+        {
+            throw new InvalidOperationException("This cache does not create entries on demand");
+        }
+
+        private Guid LookupGuidForMapping(string entityName, string[] filterFields, object[] filterValues)
+        {
+            QueryExpression query = new QueryExpression
+            {
+                EntityName = entityName,
+                ColumnSet = new ColumnSet(false)
+            };
+
+            for (int i = 0; i < filterFields.Length; i++)
+            {
+                if (!(filterValues[i] is EntityReference entRefValue))
+                {
+                    query.Criteria.AddCondition(filterFields[i], ConditionOperator.Equal, filterValues[i]);
+                }
+                else
+                {
+                    Guid refId = entRefValue.Id;
+                    query.Criteria.AddCondition(filterFields[i], ConditionOperator.Equal, refId);
+                }
+            }
+
+            var entities = orgService.GetDataByQuery(query, 2).Entities.ToList();
+
+            if (entities.Count > 1)
+            {
+                throw new ConfigurationException($"incorrect mapping value - cannot find unique record, Found {entities.Count} maching criteria {entityName}:{string.Join(",", filterFields)}={string.Join(", ", filterValues)}");
+            }
+
+            if (entities.Count == 0)
+            {
+                return Guid.Empty;
+            }
+
+            return entities[0].Id;
+        }
+    }
+}

--- a/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Core/Capgemini.Xrm.DataMigration.Core.csproj
@@ -75,6 +75,8 @@
     <Compile Include="..\..\GlobalSuppressions.cs">
       <Link>GlobalSuppressions.cs</Link>
     </Compile>
+    <Compile Include="Cache\EntityMapLookupCache.cs" />
+    <Compile Include="Cache\EntityAttributeCache.cs" />
     <Compile Include="Cache\EntityMetadataCache.cs" />
     <Compile Include="Config\CrmSchemaConfiguration.cs" />
     <Compile Include="Config\ICrmGenericImporterConfig.cs" />

--- a/src/Capgemini.Xrm.DataMigration.Core/Config/ICrmGenericImporterConfig.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Config/ICrmGenericImporterConfig.cs
@@ -70,6 +70,11 @@ namespace Capgemini.Xrm.DataMigration.Config
         List<string> NoUpdateEntities { get; }
 
         /// <summary>
+        /// If true, updates to existing records with correct data are suppressed.
+        /// </summary>
+        bool SkipExistingRecords { get; set; }
+
+        /// <summary>
         /// Allow caalers to reset ProcessesToDeactivate list.
         /// </summary>
         void ResetProcessesToDeactivate();

--- a/src/Capgemini.Xrm.DataMigration.Core/Extensions/OrgServiceExtensions.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Extensions/OrgServiceExtensions.cs
@@ -29,7 +29,7 @@ namespace Capgemini.Xrm.DataMigration.Extensions
             return orgService.GetDataByQuery(query, pageSize, true);
         }
 
-        public static EntityCollection GetDataByQuery(this IOrganizationService orgService, QueryExpression query, int pageSize, bool shouldIncudeEntityCollection = true)
+        public static EntityCollection GetDataByQuery(this IOrganizationService orgService, QueryExpression query, int pageSize, bool shouldIncudeEntityCollection = true, int maxRecords = int.MaxValue)
         {
             query.ThrowArgumentNullExceptionIfNull(nameof(query));
             orgService.ThrowArgumentNullExceptionIfNull(nameof(orgService));
@@ -46,6 +46,13 @@ namespace Capgemini.Xrm.DataMigration.Extensions
             while (true)
             {
                 var pagedResults = orgService.RetrieveMultiple(query);
+
+                maxRecords -= pagedResults.Entities.Count;
+
+                if (maxRecords < 0)
+                {
+                    return null; // maximum exceeded
+                }
 
                 if (shouldIncudeEntityCollection)
                 {

--- a/src/Capgemini.Xrm.DataMigration.Core/Extensions/OrgServiceExtensions.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Extensions/OrgServiceExtensions.cs
@@ -47,13 +47,6 @@ namespace Capgemini.Xrm.DataMigration.Extensions
             {
                 var pagedResults = orgService.RetrieveMultiple(query);
 
-                maxRecords -= pagedResults.Entities.Count;
-
-                if (maxRecords < 0)
-                {
-                    return null; // maximum exceeded
-                }
-
                 if (shouldIncudeEntityCollection)
                 {
                     if (query.PageInfo.PageNumber == 1)
@@ -71,7 +64,9 @@ namespace Capgemini.Xrm.DataMigration.Extensions
                     allResults.TotalRecordCount += pagedResults.Entities.Count;
                 }
 
-                if (pagedResults.MoreRecords)
+                maxRecords -= pagedResults.Entities.Count;
+
+                if (pagedResults.MoreRecords && maxRecords > 0)
                 {
                     query.PageInfo.PageNumber++;
                     query.PageInfo.PagingCookie = pagedResults.PagingCookie;

--- a/src/Capgemini.Xrm.DataMigration.Core/Repositories/EntityRepository.cs
+++ b/src/Capgemini.Xrm.DataMigration.Core/Repositories/EntityRepository.cs
@@ -20,6 +20,7 @@ namespace Capgemini.Xrm.DataMigration.Repositories
     {
         private readonly IEntityMetadataCache metadataCache;
         private readonly IOrganizationService orgService;
+        private readonly EntityMapLookupCache mapLookupCache;
         private readonly IRetryExecutor retryExecutor;
         private readonly Dictionary<string, Guid> MappingCache = new Dictionary<string, Guid>();
 
@@ -32,7 +33,8 @@ namespace Capgemini.Xrm.DataMigration.Repositories
         {
             this.orgService = orgService;
             this.retryExecutor = retryExecutor;
-            metadataCache = entMetadataCache;
+            this.metadataCache = entMetadataCache;
+            this.mapLookupCache = new EntityMapLookupCache(orgService);
         }
 
         /// <summary>
@@ -229,53 +231,7 @@ namespace Capgemini.Xrm.DataMigration.Repositories
 
         public Guid GetGuidForMapping(string entityName, string[] filterFields, object[] filterValues)
         {
-            lock (this)
-            {
-                if (filterFields == null || filterValues == null || filterFields.Length != filterValues.Length)
-                {
-                    throw new ArgumentException("filter fields must have same length as filter values!");
-                }
-
-                var cacheKey = entityName + "|" + string.Join(";", filterFields) + "|" + string.Join(";", (from f in filterValues select f?.ToString() ?? "NULL"));
-                if (MappingCache.TryGetValue(cacheKey, out Guid cachedResult))
-                {
-                    return cachedResult;
-                }
-
-                QueryExpression query = new QueryExpression
-                {
-                    EntityName = entityName,
-                    ColumnSet = new ColumnSet(false)
-                };
-
-                for (int i = 0; i < filterFields.Length; i++)
-                {
-                    if (!(filterValues[i] is EntityReference entRefValue))
-                    {
-                        query.Criteria.AddCondition(filterFields[i], ConditionOperator.Equal, filterValues[i]);
-                    }
-                    else
-                    {
-                        Guid refId = entRefValue.Id;
-                        query.Criteria.AddCondition(filterFields[i], ConditionOperator.Equal, refId);
-                    }
-                }
-
-                List<Entity> entities = orgService.GetDataByQuery(query, 2).Entities.ToList();
-
-                if (entities.Count > 1)
-                {
-                    throw new ConfigurationException($"incorrect mapping value - cannot find unique record, Found {entities.Count} maching criteria {entityName}:{string.Join(",", filterFields)}={string.Join(", ", filterValues)}");
-                }
-
-                if (entities.Count == 0)
-                {
-                    return Guid.Empty;
-                }
-
-                MappingCache[cacheKey] = entities[0].Id;
-                return entities[0].Id;
-            }
+            return this.mapLookupCache.GetGuidForMapping(entityName, filterFields, filterValues);
         }
 
         /// <summary>

--- a/src/Capgemini.Xrm.DataMigration.CrmStore/Config/CrmGenericImporterConfig.cs
+++ b/src/Capgemini.Xrm.DataMigration.CrmStore/Config/CrmGenericImporterConfig.cs
@@ -40,6 +40,11 @@ namespace Capgemini.Xrm.DataMigration.CrmStore.Config
         public List<EntityToBeObfuscated> FieldsToObfuscate { get; private set; } = new List<EntityToBeObfuscated>();
 
         /// <summary>
+        /// If true, updates to existing records with correct data are suppressed.
+        /// </summary>
+        public bool SkipExistingRecords { get; set; }
+
+        /// <summary>
         /// Allow caalers to reset ProcessesToDeactivate list.
         /// </summary>
         public void ResetProcessesToDeactivate()

--- a/src/Capgemini.Xrm.DataMigration.CrmStore/Config/CrmImportConfig.cs
+++ b/src/Capgemini.Xrm.DataMigration.CrmStore/Config/CrmImportConfig.cs
@@ -183,6 +183,11 @@ namespace Capgemini.Xrm.DataMigration.CrmStore.Config
         public List<string> NoUpdateEntities { get; private set; } = new List<string>();
 
         /// <summary>
+        /// If true, updates to existing records with correct data are suppressed.
+        /// </summary>
+        public bool SkipExistingRecords { get; set; }
+
+        /// <summary>
         /// Reads settings from file.
         /// </summary>
         /// <param name="filePath">filePath.</param>

--- a/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
+++ b/src/Capgemini.Xrm.DataMigration.Engine/Capgemini.Xrm.DataMigration.Engine.csproj
@@ -96,6 +96,7 @@
     <Compile Include="DataProcessors\ObfuscateFieldsProcessor.cs" />
     <Compile Include="DataProcessors\ObjectTypeCodeProcessor.cs" />
     <Compile Include="DataProcessors\NoUpdateProcessor.cs" />
+    <Compile Include="DataProcessors\SkipExistingRecordProcessor.cs" />
     <Compile Include="GlobalSuppressions1.cs" />
     <Compile Include="MappingRules\BusinessUnitRootRule.cs" />
     <Compile Include="MappingRules\MappingAliasedValueRule.cs" />

--- a/src/Capgemini.Xrm.DataMigration.Engine/CrmGenericImporter.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/CrmGenericImporter.cs
@@ -70,6 +70,11 @@ namespace Capgemini.Xrm.DataMigration.Engine
 
             AddProcessor(new MapEntityProcessor(config.MigrationConfig, Logger, targetEntRepo, config.PassOneReferences));
 
+            if (config.SkipExistingRecords)
+            {
+                AddProcessor(new SkipExistingRecordProcessor(Logger, targetEntRepo));
+            }
+
             if (config.EntitiesToSync != null && config.EntitiesToSync.Count > 0)
             {
                 AddProcessor(new SyncEntitiesProcessor(config.EntitiesToSync, targetEntRepo, Logger));

--- a/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/SkipExistingRecordProcessor.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/SkipExistingRecordProcessor.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Capgemini.DataMigration.Core;
+using Capgemini.DataMigration.Core.Extensions;
+using Capgemini.DataMigration.Exceptions;
+using Capgemini.Xrm.DataMigration.Config;
+using Capgemini.Xrm.DataMigration.Core;
+using Capgemini.Xrm.DataMigration.DataStore;
+using Capgemini.Xrm.DataMigration.Engine.MappingRules;
+using Capgemini.Xrm.DataMigration.Model;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Capgemini.Xrm.DataMigration.Extensions;
+
+namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
+{
+    public class SkipExistingRecordProcessor : IEntityProcessor<Entity, EntityWrapper>
+    {
+        private const int MaxCachedrecords = 20000;
+        private readonly ILogger logger;
+        private readonly IEntityRepository targetRepo;
+        private Dictionary<string, Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>> cachedRecordKeys = new Dictionary<string, Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>>();
+
+        public SkipExistingRecordProcessor(ILogger logger, IEntityRepository targetRepo)
+        {
+            this.logger = logger;
+            this.targetRepo = targetRepo;
+        }
+
+        public int MinRequiredPassNumber
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        public void ProcessEntity(EntityWrapper entity, int passNumber, int maxPassNumber)
+        {
+            try
+            {
+                entity.ThrowArgumentNullExceptionIfNull(nameof(entity));
+
+                lock (this)
+                {
+                    if (!this.cachedRecordKeys.ContainsKey(entity.LogicalName))
+                    {
+                        var fieldsToMatch = (from a in entity.OriginalEntity.Attributes where !(a.Value is AliasedValue) select a.Key).ToArray();
+                        var recordCache = new Dictionary<Guid, KeyValuePair<string, string>[]>();
+                        this.cachedRecordKeys[entity.LogicalName] = new Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>(fieldsToMatch, recordCache);
+
+                        var query = new QueryExpression(entity.LogicalName)
+                        {
+                            ColumnSet = new ColumnSet(fieldsToMatch.ToArray())
+                        };
+
+                        var results = this.targetRepo.GetCurrentOrgService.GetDataByQuery(query, MaxCachedrecords, true, MaxCachedrecords);
+
+                        if (results == null)
+                        {
+                            this.logger.LogWarning("Record skipping skipped, too many records returned");
+                        }
+                        else
+                        {
+                            var tempList = new List<KeyValuePair<string, string>>();
+
+                            foreach (var record in results.Entities)
+                            {
+                                tempList.Clear();
+
+                                foreach (var field in fieldsToMatch)
+                                {
+                                    tempList.Add(new KeyValuePair<string, string>(field, GetFieldValueAsText(record, field)));
+                                }
+
+                                recordCache[record.Id] = tempList.ToArray();
+                            }
+
+                            this.logger.LogInfo($"Cached {recordCache.Count} records of type {entity.LogicalName} for skipping {GetType().FullName}");
+                        }
+                    }
+                }
+
+                if (entity.OperationType != OperationType.Ignore)
+                {
+                    lock (this)
+                    {
+                        if (this.cachedRecordKeys[entity.LogicalName].Item2.TryGetValue(entity.OriginalEntity.Id, out KeyValuePair<string, string>[] fields))
+                        {
+                            var allFound = true;
+                            var fieldsToMatch = this.cachedRecordKeys[entity.LogicalName].Item1;
+
+                            foreach (var attr in entity.OriginalEntity.Attributes)
+                            {
+                                if (fieldsToMatch.Contains(attr.Key))
+                                {
+                                    var val = GetFieldValueAsText(entity.OriginalEntity, attr.Key);
+                                    var found = (from f in fields where f.Key == attr.Key && f.Value == val select f).Any();
+                                    allFound = allFound && found;
+                                }
+                            }
+
+                            if (allFound)
+                            {
+                                entity.OperationType = OperationType.Ignore;
+                                logger.LogInfo($"Skipping {entity.LogicalName} {entity.OriginalEntity.Id}");
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"{GetType().FullName}: Processing Error", ex);
+                throw;
+            }
+        }
+
+        public void ImportStarted()
+        {
+            logger.LogInfo($"Executing {nameof(ImportStarted)}");
+        }
+
+        public void ImportCompleted()
+        {
+            logger.LogInfo($"Executing {nameof(ImportCompleted)}");
+        }
+
+        private string GetFieldValueAsText(Entity e, string field)
+        {
+            object val = e.Contains(field) ? e[field] : null;
+
+            if (val != null)
+            {
+                if (val is EntityReference)
+                {
+                    return ((EntityReference)val).Id.ToString();
+                }
+                else if (val is OptionSetValue)
+                {
+                    return ((OptionSetValue)val).Value.ToString();
+                }
+                else if (val is Money)
+                {
+                    return ((Money)val).Value.ToString();
+                }
+                else
+                {
+                    return val.ToString();
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/SkipExistingRecordProcessor.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/SkipExistingRecordProcessor.cs
@@ -3,24 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using Capgemini.DataMigration.Core;
 using Capgemini.DataMigration.Core.Extensions;
-using Capgemini.DataMigration.Exceptions;
-using Capgemini.Xrm.DataMigration.Config;
+using Capgemini.Xrm.DataMigration.Cache;
 using Capgemini.Xrm.DataMigration.Core;
 using Capgemini.Xrm.DataMigration.DataStore;
-using Capgemini.Xrm.DataMigration.Engine.MappingRules;
-using Capgemini.Xrm.DataMigration.Model;
 using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Query;
-using Capgemini.Xrm.DataMigration.Extensions;
 
 namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
 {
     public class SkipExistingRecordProcessor : IEntityProcessor<Entity, EntityWrapper>
     {
-        private const int MaxCachedrecords = 20000;
         private readonly ILogger logger;
         private readonly IEntityRepository targetRepo;
-        private Dictionary<string, Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>> cachedRecordKeys = new Dictionary<string, Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>>();
+        private Dictionary<string, EntityAttributeCache> cachedRecords = new Dictionary<string, EntityAttributeCache>();
 
         public SkipExistingRecordProcessor(ILogger logger, IEntityRepository targetRepo)
         {
@@ -44,9 +38,11 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
 
                 lock (this)
                 {
-                    if (!this.cachedRecordKeys.ContainsKey(entity.LogicalName))
+                    if (!this.cachedRecords.ContainsKey(entity.LogicalName))
                     {
-                        CacheEntityRecords(entity);
+                        var cache = new EntityAttributeCache(this.targetRepo.GetCurrentOrgService, entity.LogicalName, (from a in entity.OriginalEntity.Attributes where !(a.Value is AliasedValue) select a.Key).ToArray());
+                        cache.LoadAllRecords();
+                        this.cachedRecords[entity.LogicalName] = cache;
                     }
                 }
 
@@ -54,26 +50,13 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
                 {
                     lock (this)
                     {
-                        if (this.cachedRecordKeys[entity.LogicalName].Item2.TryGetValue(entity.OriginalEntity.Id, out KeyValuePair<string, string>[] fields))
+                        var cache = this.cachedRecords[entity.LogicalName];
+                        var fields = (from a in entity.OriginalEntity.Attributes select new KeyValuePair<string, string>(a.Key, EntityAttributeCache.GetFieldValueAsText(a.Value))).ToArray();
+
+                        if (cache.MatchCachedEntityAttributes(entity.Id, fields))
                         {
-                            var allFound = true;
-                            var fieldsToMatch = this.cachedRecordKeys[entity.LogicalName].Item1;
-
-                            foreach (var attr in entity.OriginalEntity.Attributes)
-                            {
-                                if (fieldsToMatch.Contains(attr.Key))
-                                {
-                                    var val = GetFieldValueAsText(entity.OriginalEntity, attr.Key);
-                                    var found = (from f in fields where f.Key == attr.Key && f.Value == val select f).Any();
-                                    allFound = allFound && found;
-                                }
-                            }
-
-                            if (allFound)
-                            {
-                                entity.OperationType = OperationType.Ignore;
-                                logger.LogInfo($"Skipping {entity.LogicalName} {entity.OriginalEntity.Id}");
-                            }
+                            entity.OperationType = OperationType.Ignore;
+                            logger.LogInfo($"Skipping {entity.LogicalName} {entity.OriginalEntity.Id}");
                         }
                     }
                 }
@@ -93,70 +76,6 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
         public void ImportCompleted()
         {
             logger.LogInfo($"Executing {nameof(ImportCompleted)}");
-        }
-
-        private void CacheEntityRecords(EntityWrapper entity)
-        {
-            var fieldsToMatch = (from a in entity.OriginalEntity.Attributes where !(a.Value is AliasedValue) select a.Key).ToArray();
-            var recordCache = new Dictionary<Guid, KeyValuePair<string, string>[]>();
-            this.cachedRecordKeys[entity.LogicalName] = new Tuple<string[], Dictionary<Guid, KeyValuePair<string, string>[]>>(fieldsToMatch, recordCache);
-
-            var query = new QueryExpression(entity.LogicalName)
-            {
-                ColumnSet = new ColumnSet(fieldsToMatch.ToArray())
-            };
-
-            var results = this.targetRepo.GetCurrentOrgService.GetDataByQuery(query, MaxCachedrecords, true, MaxCachedrecords);
-
-            if (results == null)
-            {
-                this.logger.LogWarning("Record skipping skipped, too many records returned");
-            }
-            else
-            {
-                var tempList = new List<KeyValuePair<string, string>>();
-
-                foreach (var record in results.Entities)
-                {
-                    tempList.Clear();
-
-                    foreach (var field in fieldsToMatch)
-                    {
-                        tempList.Add(new KeyValuePair<string, string>(field, GetFieldValueAsText(record, field)));
-                    }
-
-                    recordCache[record.Id] = tempList.ToArray();
-                }
-
-                this.logger.LogInfo($"Cached {recordCache.Count} records of type {entity.LogicalName} for skipping {GetType().FullName}");
-            }
-        }
-
-        private string GetFieldValueAsText(Entity e, string field)
-        {
-            object val = e.Contains(field) ? e[field] : null;
-
-            if (val != null)
-            {
-                if (val is EntityReference)
-                {
-                    return ((EntityReference)val).Id.ToString();
-                }
-                else if (val is OptionSetValue)
-                {
-                    return ((OptionSetValue)val).Value.ToString();
-                }
-                else if (val is Money)
-                {
-                    return ((Money)val).Value.ToString();
-                }
-                else
-                {
-                    return val.ToString();
-                }
-            }
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
New logic to allow updates to be skipped where nothing has changed, plus caching improvements.  In tests reduces the deployment time from 15 minutes to 10 seconds where the data is already in place. 