### PR TITLE
fix: issue where NoUpdateEntities was always ignored

### DIFF
--- a/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/NoUpdateProcessor.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/NoUpdateProcessor.cs
@@ -40,9 +40,9 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
         {
             entity.ThrowArgumentNullExceptionIfNull(nameof(entity));
 
-            if (noUpdateEntities.Contains(entity.LogicalName) && passNumber != (int)PassType.CreateRequiredEntity && passNumber != (int)PassType.CreateEntity)
+            if (noUpdateEntities.Contains(entity.LogicalName) && (passNumber == (int)PassType.CreateRequiredEntity || passNumber == (int)PassType.CreateEntity))
             {
-                entity.OperationType = OperationType.Ignore;
+                entity.OperationType = OperationType.Create;
             }
         }
     }

--- a/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/DataProcessors/NoUpdateProcessorTests.cs
+++ b/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/DataProcessors/NoUpdateProcessorTests.cs
@@ -78,7 +78,7 @@ namespace Capgemini.Xrm.DataMigration.Engine.Tests.Unit.DataProcessors
 
             systemUnderTest.ProcessEntity(entityWrapper, pass, 100);
 
-            Assert.AreNotEqual(OperationType.Ignore, entityWrapper.OperationType);
+            entityWrapper.OperationType.Should().Be(OperationType.Create);
         }
 
         [DataTestMethod]
@@ -93,7 +93,7 @@ namespace Capgemini.Xrm.DataMigration.Engine.Tests.Unit.DataProcessors
 
             systemUnderTest.ProcessEntity(entityWrapper, pass, 100);
 
-            Assert.AreEqual(OperationType.Ignore, entityWrapper.OperationType);
+            entityWrapper.OperationType.Should().Be(OperationType.New);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Fixed an issue with the implementation of `NoUpdateEntities`. I've also updated the [wiki ](https://github.com/Capgemini/xrm-datamigration/wiki/Config) to document this functionality.