### PR TITLE
perf: cache alias mapping results

### DIFF
--- a/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/MapEntityProcessor.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/DataProcessors/MapEntityProcessor.cs
@@ -52,8 +52,8 @@ namespace Capgemini.Xrm.DataMigration.Engine.DataProcessors
                 {
                     entitySpecificRules = new List<IMappingRule>()
                     {
-                new BusinessUnitRootRule(targetBusinessUnitId),
-                new MappingAliasedValueRule(targetRepo)
+                        new BusinessUnitRootRule(targetBusinessUnitId),
+                        new MappingAliasedValueRule(targetRepo)
                     };
                 }
 

--- a/src/Capgemini.Xrm.DataMigration.Engine/MappingRules/MappingAliasedValueRule.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/MappingRules/MappingAliasedValueRule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Capgemini.Xrm.DataMigration.Core;
@@ -12,23 +13,77 @@ namespace Capgemini.Xrm.DataMigration.Engine.MappingRules
     public class MappingAliasedValueRule : IMappingRule
     {
         private readonly IEntityRepository entityRepository;
+        private readonly Dictionary<AliasMapCacheKey, Guid> cache;
 
         public MappingAliasedValueRule(IEntityRepository entityRepository)
         {
             this.entityRepository = entityRepository;
+            this.cache = new Dictionary<AliasMapCacheKey, Guid>();
         }
 
         public bool ProcessImport(string aliasedAttributeName, List<AliasedValue> values, out object replacementValue)
         {
-            string entName = values.Select(p => p.EntityLogicalName).Distinct().Single();
+            var entityName = values.Select(p => p.EntityLogicalName).Distinct().Single();
+            var attributeNames = values.Select(p => p.AttributeLogicalName).ToArray();
+            var attributeValues = values.Select(p => p.Value).ToArray();
 
-            List<string> attrNames = values.Select(p => p.AttributeLogicalName).ToList();
-
-            List<object> attrValues = values.Select(p => p.Value).ToList();
-
-            replacementValue = entityRepository.GetGuidForMapping(entName, attrNames.ToArray(), attrValues.ToArray());
+            var cacheKey = new AliasMapCacheKey(entityName, attributeNames, attributeValues);
+            if (cache.TryGetValue(cacheKey, out Guid cachedValue))
+            {
+                replacementValue = cachedValue;
+            }
+            else
+            {
+                replacementValue = entityRepository.GetGuidForMapping(entityName, attributeNames, attributeValues);
+                cache.Add(cacheKey, (Guid)replacementValue);
+            }
 
             return (Guid)replacementValue != Guid.Empty;
+        }
+
+        private class AliasMapCacheKey
+        {
+            public AliasMapCacheKey(string entityName, IEnumerable<string> attributeNames, IEnumerable<object> attributeValues)
+            {
+                this.EntityName = entityName;
+                this.AttributeNames = attributeNames;
+                this.AttributeValues = attributeValues;
+            }
+
+            public string EntityName { get; private set; }
+
+            public IEnumerable<string> AttributeNames { get; private set; }
+
+            public IEnumerable<object> AttributeValues { get; private set; }
+
+            public override bool Equals(object obj)
+            {
+                if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+                {
+                    return false;
+                }
+
+                var other = (AliasMapCacheKey)obj;
+
+                return
+                    this.EntityName == other.EntityName &&
+                    this.AttributeNames.SequenceEqual(other.AttributeNames) &&
+                    this.AttributeValues.SequenceEqual(other.AttributeValues);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hash = 17;
+
+                    hash = (hash * 23) + this.EntityName.GetHashCode();
+                    hash = (hash * 23) + ((IStructuralEquatable)this.AttributeNames).GetHashCode(EqualityComparer<string>.Default);
+                    hash = (hash * 23) + ((IStructuralEquatable)this.AttributeValues).GetHashCode(EqualityComparer<object>.Default);
+
+                    return hash;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I can't think of a reason not to cache these. I would have preferred to have done all mapping in memory (perhaps for data sets under a certain size) but that would be a much more invasive change.

This relatively minor fix brings down an import job that takes us 25 minutes to a more reasonable 5 minutes. It's mapping ~6000 records against a relatively small dataset (systemusers). All reference data is assigned to the same mapped user, so it makes ~6000 requests to get the same user. I imagine this is not an uncommon scenario.