### PR TITLE
fix: unable to map to some pass one references

### DIFF
--- a/src/Capgemini.Xrm.DataMigration.Engine/MappingRules/MappingAliasedValueRule.cs
+++ b/src/Capgemini.Xrm.DataMigration.Engine/MappingRules/MappingAliasedValueRule.cs
@@ -35,7 +35,11 @@ namespace Capgemini.Xrm.DataMigration.Engine.MappingRules
             else
             {
                 replacementValue = entityRepository.GetGuidForMapping(entityName, attributeNames, attributeValues);
-                cache.Add(cacheKey, (Guid)replacementValue);
+
+                if ((Guid)replacementValue != Guid.Empty)
+                {
+                    cache.Add(cacheKey, (Guid)replacementValue);
+                }
             }
 
             return (Guid)replacementValue != Guid.Empty;

--- a/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/MappingRules/MappingAliasedValueRuleTests.cs
+++ b/tests/Capgemini.Xrm.DataMigration.Engine.Tests.Unit/MappingRules/MappingAliasedValueRuleTests.cs
@@ -76,5 +76,32 @@ namespace Capgemini.Xrm.DataMigration.Engine.Tests.Unit.MappingRules
 
             replacementValue.Should().BeEquivalentTo(returnedGuid);
         }
+
+        [TestMethod]
+        public void ProcessImportEmptyGuidsAreNotCached()
+        {
+            string aliasedAttributeName = "accountid";
+            var firstValues = new List<AliasedValue>()
+            {
+                new AliasedValue("account", "name", "Test Account"),
+            };
+            var secondValues = new List<AliasedValue>()
+            {
+                new AliasedValue("account", "name", "Test Account"),
+            };
+            MockEntityRepo
+                .Setup(r => r.GetGuidForMapping(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<object[]>()))
+                .Returns(Guid.Empty);
+
+            systemUnderTest.ProcessImport(aliasedAttributeName, firstValues, out object replacementValue);
+            systemUnderTest.ProcessImport(aliasedAttributeName, secondValues, out replacementValue);
+
+            MockEntityRepo.Verify(
+                r => r.GetGuidForMapping(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<object[]>()),
+                Times.Exactly(2),
+                "Expected empty GUIDs not to be cached but they were.");
+
+            replacementValue.Should().BeEquivalentTo(Guid.Empty);
+        }
     }
 }


### PR DESCRIPTION
The caching applied in https://github.com/Capgemini/xrm-datamigration/commit/b2381c76a4feeb7cd275aed6b0fb5885177fe107 introduced a potentially breaking change for data imports where the alias mapping caches an empty GUID in pass zero for a record that gets created in pass zero. Pass one would then not be able to map to these records as a result of the cached empty GUID.

This change reverts that breaking change at the cost of worst case mapping failure scenarios being about as performant as they were previously.